### PR TITLE
Upgrade order fields from integer to bigint

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Adjustment.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Adjustment.orm.xml
@@ -24,7 +24,7 @@
 
         <field name="type" column="type" type="string" />
         <field name="label" column="label" type="string" nullable="true" />
-        <field name="amount" column="amount" type="integer" />
+        <field name="amount" column="amount" type="bigint" />
         <field name="neutral" column="is_neutral" type="boolean" />
         <field name="locked" column="is_locked" type="boolean" />
         <field name="originCode" column="origin_code" type="string" nullable="true" />

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Order.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Order.orm.xml
@@ -41,9 +41,9 @@
             </cascade>
         </one-to-many>
 
-        <field name="itemsTotal" column="items_total" type="integer" />
-        <field name="adjustmentsTotal" column="adjustments_total" type="integer" />
-        <field name="total" column="total" type="integer" />
+        <field name="itemsTotal" column="items_total" type="bigint" />
+        <field name="adjustmentsTotal" column="adjustments_total" type="bigint" />
+        <field name="total" column="total" type="bigint" />
 
         <field name="createdAt" column="created_at" type="datetime">
             <gedmo:timestampable on="create"/>

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItem.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItem.orm.xml
@@ -22,10 +22,10 @@
         </id>
 
         <field name="quantity" column="quantity" type="integer" />
-        <field name="unitPrice" column="unit_price" type="integer" />
-        <field name="unitsTotal" column="units_total" type="integer" />
-        <field name="adjustmentsTotal" column="adjustments_total" type="integer" />
-        <field name="total" column="total" type="integer" />
+        <field name="unitPrice" column="unit_price" type="bigint" />
+        <field name="unitsTotal" column="units_total" type="bigint" />
+        <field name="adjustmentsTotal" column="adjustments_total" type="bigint" />
+        <field name="total" column="total" type="bigint" />
         <field name="immutable" column="is_immutable" type="boolean" />
 
         <many-to-one field="order" target-entity="Sylius\Component\Order\Model\OrderInterface" inversed-by="items">

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItemUnit.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItemUnit.orm.xml
@@ -21,7 +21,7 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field name="adjustmentsTotal" column="adjustments_total" type="integer" />
+        <field name="adjustmentsTotal" column="adjustments_total" type="bigint" />
 
         <many-to-one field="orderItem" target-entity="Sylius\Component\Order\Model\OrderItemInterface" inversed-by="units">
             <join-column name="order_item_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/PaymentBundle/Resources/config/doctrine/model/Payment.orm.xml
+++ b/src/Sylius/Bundle/PaymentBundle/Resources/config/doctrine/model/Payment.orm.xml
@@ -24,7 +24,7 @@
         </many-to-one>
 
         <field name="currencyCode" column="currency_code" length="3" type="string" />
-        <field name="amount" column="amount" type="integer" />
+        <field name="amount" column="amount" type="bigint" />
         <field name="state" column="state" type="string" />
         <field name="details" column="details" type="json_array" />
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | ^1.9.0
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | mentioned in https://github.com/Sylius/Sylius/pull/11526
| License         | MIT

(see #1 )

In my case, order items pricings were in different currency, so it can be a extreme large amount for some region & currency. Therefore I need to change the 

(but as https://github.com/Sylius/Sylius/pull/11526#pullrequestreview-421959789 said, this changes may cause issues, I need to follow up this later) 